### PR TITLE
Add aliasing to Components and Contexts, and associated babel config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,4 +22,13 @@ module.exports = {
     'react',
   ],
   rules: {},
+  settings: {
+    'import/resolver': {
+      alias: {
+        map: [
+          ['@Components', './client/src/components'],
+          ['@Contexts', './client/src/contexts']
+        ]
+      }
+    }
 };

--- a/client/src/components/Overview/Overview.jsx
+++ b/client/src/components/Overview/Overview.jsx
@@ -7,7 +7,7 @@ import StyleSelector from './StyleSelector/StyleSelector';
 import AddToCart from './AddToCart';
 import ProductDescription from './ProductDescription';
 
-import { ActiveStyleProvider } from '../../contexts/ActiveStyleId';
+import { ActiveStyleProvider } from '@Contexts/ActiveStyleId';
 
 function Overview() {
   return (

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "babel-plugin-styled-components": "^2.0.6",
         "eslint": "^8.12.0",
         "eslint-config-airbnb": "^19.0.4",
+        "eslint-import-resolver-webpack": "^0.13.2",
         "eslint-plugin-import": "^2.25.4",
         "eslint-plugin-jsx-a11y": "^6.5.1",
         "eslint-plugin-react": "^7.29.4",
@@ -3004,6 +3005,12 @@
         "node": ">=6.0"
       }
     },
+    "node_modules/array-find": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-find/-/array-find-1.0.0.tgz",
+      "integrity": "sha1-bI4obRHtdoMn+OYuzuhzU8o+eLg=",
+      "dev": true
+    },
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -4513,6 +4520,79 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true
     },
+    "node_modules/eslint-import-resolver-webpack": {
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-webpack/-/eslint-import-resolver-webpack-0.13.2.tgz",
+      "integrity": "sha512-XodIPyg1OgE2h5BDErz3WJoK7lawxKTJNhgPNafRST6csC/MZC+L5P6kKqsZGRInpbgc02s/WZMrb4uGJzcuRg==",
+      "dev": true,
+      "dependencies": {
+        "array-find": "^1.0.0",
+        "debug": "^3.2.7",
+        "enhanced-resolve": "^0.9.1",
+        "find-root": "^1.1.0",
+        "has": "^1.0.3",
+        "interpret": "^1.4.0",
+        "is-core-module": "^2.7.0",
+        "is-regex": "^1.1.4",
+        "lodash": "^4.17.21",
+        "resolve": "^1.20.0",
+        "semver": "^5.7.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      },
+      "peerDependencies": {
+        "eslint-plugin-import": ">=1.4.0",
+        "webpack": ">=1.11.0"
+      }
+    },
+    "node_modules/eslint-import-resolver-webpack/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-import-resolver-webpack/node_modules/enhanced-resolve": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-0.9.1.tgz",
+      "integrity": "sha1-TW5omzcl+GCQknzMhs2fFjW4ni4=",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "memory-fs": "^0.2.0",
+        "tapable": "^0.1.8"
+      },
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/eslint-import-resolver-webpack/node_modules/interpret": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/eslint-import-resolver-webpack/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/eslint-import-resolver-webpack/node_modules/tapable": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.1.10.tgz",
+      "integrity": "sha1-KcNXB8K3DlDQdIK10gLo7URtr9Q=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/eslint-module-utils": {
       "version": "2.7.3",
       "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.7.3.tgz",
@@ -5200,6 +5280,12 @@
       "funding": {
         "url": "https://github.com/avajs/find-cache-dir?sponsor=1"
       }
+    },
+    "node_modules/find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
+      "dev": true
     },
     "node_modules/find-up": {
       "version": "4.1.0",
@@ -7277,6 +7363,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/memory-fs": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.2.0.tgz",
+      "integrity": "sha1-8rslNovBIeORwlIN6Slpyu4KApA=",
+      "dev": true
     },
     "node_modules/merge-descriptors": {
       "version": "1.0.1",
@@ -11922,6 +12014,12 @@
         "@babel/runtime-corejs3": "^7.10.2"
       }
     },
+    "array-find": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-find/-/array-find-1.0.0.tgz",
+      "integrity": "sha1-bI4obRHtdoMn+OYuzuhzU8o+eLg=",
+      "dev": true
+    },
     "array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -13150,6 +13248,65 @@
         }
       }
     },
+    "eslint-import-resolver-webpack": {
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-webpack/-/eslint-import-resolver-webpack-0.13.2.tgz",
+      "integrity": "sha512-XodIPyg1OgE2h5BDErz3WJoK7lawxKTJNhgPNafRST6csC/MZC+L5P6kKqsZGRInpbgc02s/WZMrb4uGJzcuRg==",
+      "dev": true,
+      "requires": {
+        "array-find": "^1.0.0",
+        "debug": "^3.2.7",
+        "enhanced-resolve": "^0.9.1",
+        "find-root": "^1.1.0",
+        "has": "^1.0.3",
+        "interpret": "^1.4.0",
+        "is-core-module": "^2.7.0",
+        "is-regex": "^1.1.4",
+        "lodash": "^4.17.21",
+        "resolve": "^1.20.0",
+        "semver": "^5.7.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "enhanced-resolve": {
+          "version": "0.9.1",
+          "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-0.9.1.tgz",
+          "integrity": "sha1-TW5omzcl+GCQknzMhs2fFjW4ni4=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "memory-fs": "^0.2.0",
+            "tapable": "^0.1.8"
+          }
+        },
+        "interpret": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+          "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+          "dev": true
+        },
+        "tapable": {
+          "version": "0.1.10",
+          "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.1.10.tgz",
+          "integrity": "sha1-KcNXB8K3DlDQdIK10gLo7URtr9Q=",
+          "dev": true
+        }
+      }
+    },
     "eslint-module-utils": {
       "version": "2.7.3",
       "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.7.3.tgz",
@@ -13610,6 +13767,12 @@
         "make-dir": "^3.0.2",
         "pkg-dir": "^4.1.0"
       }
+    },
+    "find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
+      "dev": true
     },
     "find-up": {
       "version": "4.1.0",
@@ -15168,6 +15331,12 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+    },
+    "memory-fs": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.2.0.tgz",
+      "integrity": "sha1-8rslNovBIeORwlIN6Slpyu4KApA=",
+      "dev": true
     },
     "merge-descriptors": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "babel-plugin-styled-components": "^2.0.6",
     "eslint": "^8.12.0",
     "eslint-config-airbnb": "^19.0.4",
+    "eslint-import-resolver-webpack": "^0.13.2",
     "eslint-plugin-import": "^2.25.4",
     "eslint-plugin-jsx-a11y": "^6.5.1",
     "eslint-plugin-react": "^7.29.4",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,5 +21,9 @@ module.exports = {
   },
   resolve: {
     extensions: ['.js', '.jsx'],
+    alias: {
+      '@Components': path.resolve(__dirname, 'client/src/components/'),
+      '@Contexts': path.resolve(__dirname, 'client/src/contexts/'),
+    },
   },
 };


### PR DESCRIPTION
Associated ticket:
* https://trello.com/c/HgBBMnnp

You can now use `@Components/` or `@Contexts/` to import files without needing to pull the relative path.

IE- 

```
import StyleSelector from '@Components/Overview/StyleSelector'
import ActiveStyleId from '@Contexts/ActiveStyleId'
```

The path will be consistent, so it won't break when you move files around.