### PR TITLE
Add Click Tracking, Add Responsive Overview

### DIFF
--- a/client/src/components/Overview/AddToCart.jsx
+++ b/client/src/components/Overview/AddToCart.jsx
@@ -5,12 +5,15 @@ import axios from 'axios';
 
 import { FiAlertTriangle } from 'react-icons/fi';
 
+import useTracking from '@Contexts/ClickTracker';
+
 import Console from '../../Console';
 
 // - Actually make the POST request when adding to cart instead of console logging.
 // - Down arrow styling for the dropdowns.
 
 function AddToCart({ skus }) {
+  const { trackEvent } = useTracking({ widget: 'Add to Cart' });
   const [selectedSku, setSelectedSku] = useState();
   const [quantity, setQuantity] = useState();
   const [error, setError] = useState(false);
@@ -73,7 +76,7 @@ function AddToCart({ skus }) {
         ) : null}
       </SelectionError>
 
-      <SelectSize defaultValue="selectsize" onChange={handleChange}>
+      <SelectSize onClick={trackEvent({ element: 'Select Size' })} defaultValue="selectsize" onChange={handleChange}>
         {anyValidSkus
           ? (
             <>

--- a/client/src/components/Overview/AddToCart.jsx
+++ b/client/src/components/Overview/AddToCart.jsx
@@ -9,7 +9,7 @@ import useTracking from '@Contexts/ClickTracker';
 
 import Console from '../../Console';
 
-// - Actually make the POST request when adding to cart instead of console logging.
+// - TODO
 // - Down arrow styling for the dropdowns.
 
 function AddToCart({ skus }) {
@@ -53,6 +53,7 @@ function AddToCart({ skus }) {
   const handleQuantity = (e) => setQuantity(e.target.value);
 
   const handleSubmit = (e) => {
+    trackEvent({ element: 'Add to Cart' });
     e.preventDefault();
     if (!selectedSku) {
       setError(true);
@@ -76,7 +77,7 @@ function AddToCart({ skus }) {
         ) : null}
       </SelectionError>
 
-      <SelectSize onClick={trackEvent({ element: 'Select Size' })} defaultValue="selectsize" onChange={handleChange}>
+      <SelectSize onClick={() => trackEvent({ element: 'Select Size' })} defaultValue="selectsize" onChange={handleChange}>
         {anyValidSkus
           ? (
             <>
@@ -91,7 +92,7 @@ function AddToCart({ skus }) {
       {anyValidSkus
         ? (
           <>
-            <SelectQuantity defaultValue="selectQuantity" onChange={handleQuantity}>
+            <SelectQuantity defaultValue="selectQuantity" onClick={() => trackEvent({ element: 'Select Quantity' })} onChange={handleQuantity}>
               {!currentStock
                 ? <option value="selectquantity">-</option>
                 : [...Array(currentStock).keys()].map((num) => (

--- a/client/src/components/Overview/AddToCart.jsx
+++ b/client/src/components/Overview/AddToCart.jsx
@@ -28,11 +28,8 @@ function AddToCart({ skus }) {
   }
 
   useEffect(() => setSelectedSku(null), [skus]);
-
-  useEffect(() => {
-    setQuantity(1);
-    setError(false);
-  }, [selectedSku]);
+  useEffect(() => setQuantity(1), [selectedSku]);
+  useEffect(() => setError(false), [selectedSku, skus]);
 
   // If selected sku isn't actually a sku (IE- the default option), don't actually set it.
   const handleChange = (e) => {
@@ -40,19 +37,17 @@ function AddToCart({ skus }) {
     setSelectedSku(newSku);
   };
 
-  const handleQuantity = (e) => setQuantity(e.target.value);
-
   const addToCart = () => {
     axios({
       method: 'POST',
       url: '/cart',
       data: { sku_id: selectedSku },
     })
-      .then(({ data }) => {
-        Console.log(`Added to cart! SKU: ${selectedSku}, COUNT: ${quantity}`, data);
-      })
+      .then(({ data }) => Console.log(`Added to cart! SKU: ${selectedSku}, COUNT: ${quantity}`, data))
       .catch((err) => Console.log(err));
   };
+
+  const handleQuantity = (e) => setQuantity(e.target.value);
 
   const handleSubmit = (e) => {
     e.preventDefault();

--- a/client/src/components/Overview/ImageGallery/Carousel.jsx
+++ b/client/src/components/Overview/ImageGallery/Carousel.jsx
@@ -55,6 +55,14 @@ const CarouselContainer = styled.nav`
   position: relative;
   width: ${CONFIG.width}px;
   height: ${(CONFIG.size * (CONFIG.itemHeight + CONFIG.spacing) - CONFIG.spacing)}px;
+  visibility: visible;
+  opacity: 1;
+  transition: opacity 0.3s linear;
+  @media (  max-width: 1280px) {
+    opacity: 0;
+    visibility: hidden;
+    transition: visibility 0s 0.3s, opacity 0.3s linear;
+  }
 `;
 
 const CarouselViewport = styled.div`

--- a/client/src/components/Overview/ImageGallery/ImageGallery.jsx
+++ b/client/src/components/Overview/ImageGallery/ImageGallery.jsx
@@ -8,7 +8,12 @@ import { FiArrowLeft, FiArrowRight, FiX } from 'react-icons/fi';
 import ZoomableImage from './ZoomableImage';
 import Carousel from './Carousel';
 
-function ImageGallery({ children, photos }) {
+function ImageGallery({
+  heading,
+  preheading,
+  content,
+  photos,
+}) {
   // Views can be ['default', 'expanded']
   const [view, setView] = useState('default');
   const [imgIdx, setImgIdx] = useState(0);
@@ -68,12 +73,77 @@ function ImageGallery({ children, photos }) {
           </ExitButton>
         </Gallery>
       </DefaultViewport>
-      <GalleryAside>
-        {children}
-      </GalleryAside>
+      <AsideContent>
+        {preheading}
+      </AsideContent>
+      <AsideHeading>
+        {heading}
+      </AsideHeading>
+      <AsideContent>
+        {content}
+      </AsideContent>
     </ExpandedViewport>
   );
 }
+
+const ExpandedViewport = styled.section`
+  background-color: ${(props) => props.theme.colors.light};
+  display: flex;
+  flex-direction: column;
+  align-content: center;
+  @media (min-width: 768px) { height: 630px; flex-wrap: wrap; }
+  @media (max-width: 768px) { width: 100%; }
+
+`;
+
+const DefaultViewport = styled.div`
+  @media (min-width: 1280px) {
+    width: 67.5%;
+    height: 630px;
+    transition: height 0.2s ease-in-out;
+  }
+  @media (max-width: 767px) {
+    height: 400px;
+    transition: height 0.2s ease-in-out;
+  }
+  @media (max-width: 1279px) and (min-width: 768px) {
+    width: 50%;
+    height: 630px;
+  }
+  overflow: visible;
+  z-index: 2;
+
+`;
+
+const AsideContent = styled.div`
+  width: 32.5%;
+  background-color:${(props) => props.theme.colors.light};
+  padding: 10px 30px;
+  color: ${(props) => props.theme.colors.secondary};
+  @media (max-width: 1279px) and (min-width: 768px) { width: 50%; }
+  @media (max-width: 768px) { width: 100%; }
+`;
+
+const AsideHeading = styled(AsideContent)`
+  @media (max-width: 768px) { order: -1; }
+`;
+
+const Gallery = styled.div`
+  width: 100%;
+  height: 100%;
+  background-color:${(props) => props.theme.colors.background};
+  &.expanded {
+    width: ${() => document.getElementById('main').offsetWidth}px;
+    transition: width 1s ease-in-out;
+    :hover { cursor: crosshair; }
+  }
+  &.default {
+    width: 100%;
+    transition: width 1s ease-in-out;
+    &:hover { cursor: zoom-in; }
+  }
+  position: relative;
+`;
 
 const VisibleInExpanded = css`
   &.expanded, &.zoom {
@@ -115,41 +185,6 @@ const CarouselPresenter = styled.div`
   left: 30px;
   transform: translate(0, -50%);
   ${VisibleInDefault}
-`;
-
-const GalleryAside = styled.div`
-  background-color:${(props) => props.theme.colors.light};
-  width: 480px;
-  padding: 10px 30px;
-  color: ${(props) => props.theme.colors.secondary};
-`;
-
-const ExpandedViewport = styled.section`
-  background-color: ${(props) => props.theme.colors.light};
-  display: flex;
-  height: 630px;
-`;
-
-const DefaultViewport = styled.div`
-  width: 800px;
-  overflow: visible;
-  z-index: 2;
-`;
-
-const Gallery = styled.div`
-  background-color:${(props) => props.theme.colors.background};
-  height: 100%;
-  &.expanded {
-    width: ${() => document.getElementById('main').offsetWidth}px;
-    transition: width 1s ease-in-out;
-    :hover { cursor: crosshair; }
-  }
-  &.default {
-    width: 100%;
-    transition: width 1s ease-in-out;
-    &:hover { cursor: zoom-in; }
-  }
-  position: relative;
 `;
 
 const Arrow = styled.span`
@@ -210,7 +245,9 @@ const Dot = styled.span`
 `;
 
 ImageGallery.propTypes = {
-  children: PropTypes.node.isRequired,
+  preheading: PropTypes.node.isRequired,
+  heading: PropTypes.node.isRequired,
+  content: PropTypes.node.isRequired,
   photos: PropTypes.arrayOf(PropTypes.shape()),
 };
 

--- a/client/src/components/Overview/ImageGallery/ZoomableImage.jsx
+++ b/client/src/components/Overview/ImageGallery/ZoomableImage.jsx
@@ -2,7 +2,10 @@ import React, { useState, useRef, useEffect } from 'react';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
 
+import useTracking from '@Contexts/ClickTracker';
+
 function ZoomableImage({ url, disabled }) {
+  const { trackEvent } = useTracking({ widget: 'Zoomable Image' });
   const [isZoomed, setIsZoomed] = useState(false);
   const zoomImg = useRef();
 
@@ -28,6 +31,7 @@ function ZoomableImage({ url, disabled }) {
     if (isZoomed) zoomOut();
     if (!isZoomed) zoomIn(e);
     setIsZoomed(!isZoomed);
+    trackEvent({ element: 'Zoom Image Toggle' });
   };
 
   useEffect(() => { if (disabled) zoomOut(); }, [disabled]);

--- a/client/src/components/Overview/Overview.jsx
+++ b/client/src/components/Overview/Overview.jsx
@@ -20,21 +20,33 @@ function Overview() {
   const currentMeta = useMeta();
   const photos = activeStyle ? activeStyle.photos : null;
 
+  const preheading = (
+    <RatingInfo>
+      <StarWrapper>
+        <Star score={currentMeta ? currentMeta.avgRating : 0} />
+      </StarWrapper>
+    </RatingInfo>
+  );
+
+  const heading = (
+    <>
+      <Category>{currentProduct && currentProduct.category}</Category>
+      <ProductName>{currentProduct ? currentProduct.name : 'Product Loading'}</ProductName>
+    </>
+  );
+
+  const content = (
+    <>
+      {activeStyle
+        && <Price original={activeStyle.original_price} discount={activeStyle.sale_price} />}
+      {activeStyle && <StyleSelector />}
+      {activeStyle && <AddToCart skus={activeStyle.skus} />}
+    </>
+  );
+
   return (
     <>
-      <ImageGallery photos={photos}>
-        <RatingInfo>
-          <StarWrapper>
-            <Star score={currentMeta ? currentMeta.avgRating : 0} />
-          </StarWrapper>
-        </RatingInfo>
-        <Category>{currentProduct && currentProduct.category}</Category>
-        <ProductName>{currentProduct ? currentProduct.name : 'Product Loading'}</ProductName>
-        {activeStyle
-        && <Price original={activeStyle.original_price} discount={activeStyle.sale_price} />}
-        {activeStyle && <StyleSelector />}
-        {activeStyle && <AddToCart skus={activeStyle.skus} />}
-      </ImageGallery>
+      <ImageGallery preheading={preheading} heading={heading} content={content} photos={photos} />
 
       <AdditionalDetails>
         <LongDescription>
@@ -84,7 +96,11 @@ const FeatureItem = styled.li`
 const AdditionalDetails = styled.section`
   color: ${(props) => props.theme.colors.secondary};
   display: flex;
+  flex-wrap: wrap;
   padding: 50px 100px;
+  @media (max-width: 767px) {
+    padding: 40px;
+  }
   & p {
     padding-top: 10px;
   }
@@ -95,11 +111,20 @@ const LongDescription = styled.div`
   width: 65%;
   padding-right: 20px;
   border-right: 1px solid ${(props) => props.theme.colors.secondary};
+  @media (max-width: 767px) {
+    width: 100%;
+    border-width: 0px;
+    padding-bottom: 20px;
+    padding-right: 0;
+  }
 `;
 
 const Features = styled.div`
   display: inline-block;
   width: 35%;
+  @media (max-width: 767px) {
+    width: 100%;
+  }
 `;
 
 const ProductName = styled.h1`

--- a/client/src/components/Overview/StyleSelector.jsx
+++ b/client/src/components/Overview/StyleSelector.jsx
@@ -5,14 +5,20 @@ import { FiCheck } from 'react-icons/fi';
 
 import { usePreviewStyle, useCurrentStyles, useActiveStyle } from '@Contexts/StylesProvider';
 
+import useTracking from '@Contexts/ClickTracker';
+
 function StyleSelector() {
   const currentStyles = useCurrentStyles();
   const { previewStyle } = usePreviewStyle();
+  const { trackEvent } = useTracking({ widget: 'Style Selector' });
 
   const { activeStyle, setActiveStyle } = useActiveStyle();
   const { setPreviewStyle } = usePreviewStyle();
 
-  const handleStyleThumbnailClick = (styleId) => setActiveStyle(styleId);
+  const handleStyleThumbnailClick = (styleId) => {
+    setActiveStyle(styleId);
+    trackEvent({ element: `Thumbnail ${styleId} Clicked` });
+  };
   const handleStyleThumbnailMouseOver = (styleId) => setPreviewStyle(styleId);
   const handleStyleThumbnailMouseOut = () => setPreviewStyle(activeStyle.style_id);
 

--- a/client/src/components/Overview/StyleSelector.jsx
+++ b/client/src/components/Overview/StyleSelector.jsx
@@ -54,8 +54,8 @@ const Thumbnails = styled.div`
   flex-direction: row;
   flex-wrap: wrap;
   justify-content: left;
-  gap: 20px;
-  max-width: 400px;
+  gap: 15px;
+  max-width: 350px;
   padding: 10px 0;
 `;
 
@@ -76,8 +76,8 @@ const SelectedThumbnail = styled.span`
 `;
 
 const Thumbnail = styled.a`
-  height: 75px;
-  width: 75px;
+  height: 69px;
+  width: 69px;
   border-radius: 50%;
   background: ${(props) => (props.thumbnail ? `url(${props.thumbnail})` : props.theme.colors.background)};
   border: 1px solid ${(props) => props.theme.colors.secondary};

--- a/client/src/contexts/ClickTracker.jsx
+++ b/client/src/contexts/ClickTracker.jsx
@@ -1,0 +1,17 @@
+import axios from 'axios';
+
+import Console from '../Console';
+
+function useTracking({ widget }) {
+  const trackEvent = ({ element }) => {
+    axios({
+      method: 'post',
+      url: '/interactions',
+      data: { element, widget, time: new Date() },
+    }).then(({ data }) => { Console.log(data, widget, element); })
+      .catch((err) => Console.log(err));
+  };
+  return { trackEvent };
+}
+
+export default useTracking;

--- a/client/src/index.jsx
+++ b/client/src/index.jsx
@@ -61,6 +61,9 @@ const Banner = styled.div`
   font-size: 0.9em;
   text-align: center;
   padding: 10px 0;
+  @media (max-width: 768px) {
+    display: none;
+  }
 `;
 
 createRoot(document.getElementById('root')).render(<App />);


### PR DESCRIPTION
### Click tracking is here!

It's really easy to add it to your widget. Check the `AddToCart.jsx` file for a demo.

There's a new file, `contexts/ClickTracker.jsx`. Technically, we should probably have made a hooks folder, but all of our hooks already live in here so I put it there for consistency.

At the top of any file you want to include click tracking in, declare it with

```
const { trackEvent } = useTracking({ widget: '<YOUR WIDGET NAME>' });
```

Then, for any element that you might want to add tracking (a link, a button, a navigation element, etc), you just need to attach a simple `onClick` handler, like this:

```
<JSXElement onClick={() => trackEvent({ element: '<NAME OF THIS ELEMENT>' })} />
```

This will fire off a post request to the Interactions API. It will log both the element clicked on and the widget it lives inside. You'll know it worked because it will log the event in the Console.

### [EDIT] Also made the overview responsive!

Mostly a CSS update, using breakpoints to reposition elements. This can get cleaned up in the next pass.

https://user-images.githubusercontent.com/67052402/163254253-dbf841d2-14a4-4f6e-9cd1-9ccf868e619c.mov


